### PR TITLE
Add quote to githash labels

### DIFF
--- a/helm/aladdin-demo/templates/commands/deploy.yaml
+++ b/helm/aladdin-demo/templates/commands/deploy.yaml
@@ -6,7 +6,7 @@ metadata:
     project: {{ .Chart.Name }}
     name: {{ .Chart.Name }}-commands
     app: {{ .Chart.Name }}-commands
-    githash: {{ .Values.deploy.imageTag }}
+    githash: {{ .Values.deploy.imageTag | quote }}
 spec:
   selector:
     matchLabels:

--- a/helm/aladdin-demo/templates/elasticsearch/configMap.yaml
+++ b/helm/aladdin-demo/templates/elasticsearch/configMap.yaml
@@ -7,7 +7,7 @@ metadata:
     project: {{ .Chart.Name }}
     app: {{ .Chart.Name }}-elasticsearch
     name: {{ .Chart.Name }}-elasticsearch
-    githash: {{ .Values.deploy.imageTag }}
+    githash: {{ .Values.deploy.imageTag | quote }}
 data:
   # When mounted, this will create a elasticsearch.yml file with the contents in elasticsearch-config template
   elasticsearch.yml: {{ include "elasticsearch-config" . | quote }}

--- a/helm/aladdin-demo/templates/elasticsearch/service.yaml
+++ b/helm/aladdin-demo/templates/elasticsearch/service.yaml
@@ -7,7 +7,7 @@ metadata:
     project: {{ .Chart.Name }}
     name: {{ .Chart.Name }}-elasticsearch
     app: {{ .Chart.Name }}-elasticsearch
-    githash: {{.Values.deploy.imageTag}}
+    githash: {{ .Values.deploy.imageTag | quote }}
 spec:
   # Setting clusterIP to None makes this a Headless Service, which is required for StatefulSet
   clusterIP: None

--- a/helm/aladdin-demo/templates/elasticsearch/statefulset.yaml
+++ b/helm/aladdin-demo/templates/elasticsearch/statefulset.yaml
@@ -7,7 +7,7 @@ metadata:
     project: {{ .Chart.Name }}
     name: {{ .Chart.Name }}-elasticsearch
     app: {{ .Chart.Name }}-elasticsearch
-    githash: {{.Values.deploy.imageTag}}
+    githash: {{ .Values.deploy.imageTag | quote }}
 spec:
   selector:
     matchLabels:

--- a/helm/aladdin-demo/templates/redis/deploy.yaml
+++ b/helm/aladdin-demo/templates/redis/deploy.yaml
@@ -7,7 +7,7 @@ metadata:
     project: {{ .Chart.Name }}
     name: {{ .Chart.Name }}-redis
     app: {{ .Chart.Name }}-redis
-    githash: {{ .Values.deploy.imageTag }}
+    githash: {{ .Values.deploy.imageTag | quote }}
 spec:
   selector:
     matchLabels:

--- a/helm/aladdin-demo/templates/redis/service.yaml
+++ b/helm/aladdin-demo/templates/redis/service.yaml
@@ -7,7 +7,7 @@ metadata:
     project: {{ .Chart.Name }}
     name: {{ .Chart.Name }}-redis
     app: {{ .Chart.Name }}-redis
-    githash: {{ .Values.deploy.imageTag }}
+    githash: {{ .Values.deploy.imageTag | quote }}
 spec:
   # No service type is specified here because the default is ClusterIP
   # This is cluster-internal, so it is only reachable from within the cluster, a private service

--- a/helm/aladdin-demo/templates/server/deploy.yaml
+++ b/helm/aladdin-demo/templates/server/deploy.yaml
@@ -6,7 +6,7 @@ metadata:
     project: {{ .Chart.Name }}
     name: {{ .Chart.Name }}-server
     app: {{ .Chart.Name }}-server
-    githash: {{ .Values.deploy.imageTag }}
+    githash: {{ .Values.deploy.imageTag | quote }}
 spec:
   selector:
     matchLabels:

--- a/helm/aladdin-demo/templates/server/hpa.yaml
+++ b/helm/aladdin-demo/templates/server/hpa.yaml
@@ -7,7 +7,7 @@ metadata:
     project: {{ .Chart.Name }}
     name: {{ .Chart.Name }}-hpa
     app: {{ .Chart.Name }}-hpa
-    githash: {{ .Values.deploy.imageTag }}
+    githash: {{ .Values.deploy.imageTag | quote }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1beta1

--- a/helm/aladdin-demo/templates/server/nginx.configMap.yaml
+++ b/helm/aladdin-demo/templates/server/nginx.configMap.yaml
@@ -7,7 +7,7 @@ metadata:
     project: {{ .Chart.Name }}
     app: {{ .Chart.Name }}-nginx
     name: {{ .Chart.Name }}-nginx
-    githash: {{ .Values.deploy.imageTag }}
+    githash: {{ .Values.deploy.imageTag | quote }}
 data:
   # Make the key the desired name for the file
   # When mounted, this will create a nginx.conf file with the contents in nginx-config template

--- a/helm/aladdin-demo/templates/server/service.yaml
+++ b/helm/aladdin-demo/templates/server/service.yaml
@@ -6,7 +6,7 @@ metadata:
     project: {{ .Chart.Name }}
     name: {{ .Chart.Name }}-server
     app: {{ .Chart.Name }}-server
-    githash: {{ .Values.deploy.imageTag }}
+    githash: {{ .Values.deploy.imageTag | quote }}
   annotations:
     service.beta.kubernetes.io/aws-load-balancer-ssl-cert: {{.Values.service.certificateArn | quote}}
     service.beta.kubernetes.io/aws-load-balancer-backend-protocol: http

--- a/helm/aladdin-demo/templates/server/uwsgi.configMap.yaml
+++ b/helm/aladdin-demo/templates/server/uwsgi.configMap.yaml
@@ -7,7 +7,7 @@ metadata:
     project: {{ .Chart.Name }}
     app: {{ .Chart.Name }}-uwsgi
     name: {{ .Chart.Name }}-uwsgi
-    githash: {{ .Values.deploy.imageTag }}
+    githash: {{ .Values.deploy.imageTag | quote }}
 data:
   # Make the key the desired name for the file
   # When mounted, this will create a uwsgi.yaml file with the contents in uwsgi-config template

--- a/helm/aladdin-demo/templates/shared/configMap.yaml
+++ b/helm/aladdin-demo/templates/shared/configMap.yaml
@@ -6,7 +6,7 @@ metadata:
     project: {{ .Chart.Name }}
     app: {{ .Chart.Name }}
     name: {{ .Chart.Name }}
-    githash: {{ .Values.deploy.imageTag }}
+    githash: {{ .Values.deploy.imageTag | quote }}
 # Create key - value entries in the data map that other files can look up
 # Load them into the environment by using configMapRef in the deploy.yaml file
 data:


### PR DESCRIPTION
Have githash label be quoted since it can be completely numerical, which doesn't work with kubernetes labels. 